### PR TITLE
Fix: TNT position

### DIFF
--- a/data/tenshiki/functions/put_tnt.mcfunction
+++ b/data/tenshiki/functions/put_tnt.mcfunction
@@ -1,3 +1,3 @@
 scoreboard players remove @s tenshiki 10
-execute at @s run summon minecraft:tnt ^ ^-1 ^-2 {Invisible:1b}
+execute at @s rotated ~ 0 run summon minecraft:tnt ^ ^-1 ^-2 {Invisible:1b}
 execute if score @s tenshiki matches 1.. run function tenshiki:put_tnt


### PR DESCRIPTION
`rotated ~ 0` を加えることで、仮想的に顔の向きを「X軸方向の回転（つまり上下の向き）に0にする」ことで上下方向の補正をしてる。
Y軸方向の回転の補正もしたかったが、`0`にすると常にZ軸方向を向いてしまうため、~でお茶を濁している。（Y軸回転は、顔と体の向きがさほど変わらないので）